### PR TITLE
Use _.includes and call it _.includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Welcome to contribute more items which you find this list is missing.
 1. [_.findIndex](#_find)
 1. [_.indexOf](#_indexOf)
 1. [_.lastIndexOf](#_lastIndexOf)
-1. [_.contains](#_contains)
+1. [_.includes](#_includes)
 1. [_.keys](#_keys)
 
 
@@ -326,13 +326,13 @@ Returns the index of the last occurrence of value in the array, or -1 if value i
 --- | --- | --- | --- | --- |
   ✔  |  ✔ |  9 ✔  |  ✔  |  ✔  |  
 
-## _.contains
+## _.includes
 
 Checks if value is in collection. 
 
   ```js
   var array = [1, 2, 3];
-  // Underscore/Lodash
+  // Underscore/Lodash - also called with _.contains
   _.includes(array, 1);
   // → true
 


### PR DESCRIPTION
You have a section called `_.contains` but you never actually use it, you use the alias. So just name the section the alias, and actually refer to it's alternate version `_.contains`, much easier to understand and keep track of