### PR TITLE
Turns the repository into an ESLint plugin!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -30,6 +30,27 @@ You are welcome to contribute with more items provided below.
 > &mdash;<cite>@therebelrobot, Maker of web things, Facilitator for Node.js/io.js</cite>
 
 
+## ESLint Plugin
+
+If you're using [ESLint](http://eslint.org/), you can install a
+[plugin](http://eslint.org/docs/user-guide/configuring#using-the-configuration-from-a-plugin) that
+will help you identify places in your codebase where you don't (may not) need Lodash/Underscore.
+
+Install the plugin...
+
+```sh
+npm install --save-dev eslint-plugin-you-may-not-need-lodash-underscore
+```
+.. then update your config.
+
+```
+'plugins': ['you-dont-need-lodash-underscore'],
+'rules': {
+  'you-dont-need-lodash-underscore/all': 1,
+  ...
+}
+```
+
 ## Quick links
 
 **[Array](#array)**

--- a/index.js
+++ b/index.js
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Discourages the use of lodash / underscore when native methods for the same functions exist.
+ * @author Patrick McElhaney
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var requireIndex = require("requireindex");
+
+//------------------------------------------------------------------------------
+// Plugin Definition
+//------------------------------------------------------------------------------
+
+
+// import all rules in lib/rules
+module.exports.rules = requireIndex(__dirname + "/lib/rules");

--- a/lib/rules/all.js
+++ b/lib/rules/all.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Discourages the use of Underscore/Lodash where native methods will do
+ * @author Patrick McElhaney
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+const errorMessages = {
+  concat: 'Consider using the native Array.concat()',
+  fill: 'Consider using the native Array.fill()',
+  find: 'Consider using the native Array.find()',
+  findIndex: 'Consider using the native Array.findIndex()',
+  indexOf: 'Consider using the native Array.indexOf()',
+  join: 'Consider using the native Array.join()',
+  lastIndexOf: 'Consider using the native Array.lastIndexOf()',
+  reverse: 'Consider using the native Array.reverse()',
+  each: 'Consider using the native Array.forEach()',
+  every: 'Consider using the native Array.every()',
+  filter: 'Consider using the native Array.filter()',
+  includes: 'Consider using the native Array.includes()',
+  map: 'Consider using the native Array.map()',
+  reduce: 'Consider using the native Array.reduce()',
+  reduceRight: 'Consider using the native Array.reduceRight()',
+  size: 'Consider using the native array length property',
+  some: 'Consider using the native Array.some()',
+  isNaN: 'Consider using the ES6 Number.isNaN function',
+  extendOwn: 'Consider using the ES6 Object.assign function',
+  assign: 'Consider using the ES6 Object.assign function',
+  keys: 'Consider using the ES6 Object.keys function',
+  repeat: 'Consider using the native repeat function',
+  toLower: 'Consider using the native toLowerCase function',
+  toUpper: 'Consider using the native toUpperCase function',
+  trim: 'Consider using the native trim function',
+};
+
+module.exports = {
+
+  create (context) {
+    function checkForUnneededLibraryFunctions (node) {
+      const functionName = getUnderscoreFunctionName(node);
+      const errorMessage = errorMessages[functionName];
+
+      if (errorMessage) {
+        context.report({
+          node,
+          message: errorMessages[functionName],
+        });
+      }
+    }
+
+    return {
+      'CallExpression': checkForUnneededLibraryFunctions,
+    };
+  },
+
+};
+
+
+function getUnderscoreFunctionName (node) {
+  const callee = node.callee;
+  return callee && callee.object && callee.object.name === '_' && callee.property && callee.property.name;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "you-dont-need-lodash-underscore",
-  "version": "3.0.0",
+  "name": "eslint-plugin-you-dont-need-lodash-underscore",
+  "version": "4.0.0",
   "description": "Lists of methods which you can use natively",
   "repository": {
     "type": "git",
@@ -8,9 +8,29 @@
   },
   "keywords": [
     "underscore",
-    "lodash"
+    "lodash",
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
   ],
   "author": "Robert Chang <cht8687@gmail.com>",
+  "contributors": [
+    "Patrick McElhaney <pmcelhaney@gmail.com> (http://patrickmcelhaney.com)"
+  ],
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "mocha tests --recursive"
+  },
+  "dependencies": {
+    "requireindex": "~1.1.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.0",
+    "mocha": "^2.5.3"
+  },
+  "engines": {
+    "node": ">=4.0"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/cht8687/You-Dont-Need-Lodash-Underscore/issues"

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Discourages the use of Underscore/Lodash where native methods will do
+ * @author Patrick McElhaney
+ */
+"use strict";
+
+var rule = require("../../../lib/rules/no-lodash-underscore"),
+
+  RuleTester = require("eslint").RuleTester;
+
+
+// Only a couple of smoke tests because otherwise it would get very reduntant
+
+var ruleTester = new RuleTester();
+ruleTester.run('no-lodash-underscore', rule, {
+
+  valid: [
+    'array.concat(2, [3], [[4]])',
+    'Object.keys({one: 1, two: 2, three: 3})'
+  ],
+
+  invalid: [
+    {
+      code: '_.concat(array, 2, [3], [[4]])',
+      errors: ['Consider using the native Array.concat()']
+    },
+    {
+      code: '_.keys({one: 1, two: 2, three: 3})',
+      errors: ['Consider using the ES6 Object.keys function']
+    },
+
+  ]
+});


### PR DESCRIPTION
Thanks for putting this repository together and congrats on making [Github Trending](https://twitter.com/trendinggithub/status/748876878279274496)! (That's how I found out about it.)

This PR turns the repository into an ESLint plugin. If you're using ESLint (you should be!) you can add this plugin to identify places in your codebase where you don't (may not) need Lodash / Underscore.

Example output:

```sh
$ grunt eslint
Running "eslint:target" (eslint) task

/code/some-project/src/account/account-details/account-header-controller.controller.js
  27:16  error  Consider using the native Array.some()  you-dont-need-lodash-underscore/all

/code/some-project/src/account/activity/activity-order-list.controller.js
  33:7   error  Consider using the native Array.forEach()   you-dont-need-lodash-underscore/all
  34:13  error  Consider using the native Array.includes()  you-dont-need-lodash-underscore/all

/code/some-projectsrc/account/holdings/holdings-chart-card.component.js
  66:16  error  Consider using the native Array.some()  you-dont-need-lodash-underscore/all

/code/some-project/src/account/relationships/relationship-service.factory.js
  40:47  error  Consider using the native Array.map()  you-dont-need-lodash-underscore/all
  40:83  error  Consider using the native Array.map()  you-dont-need-lodash-underscore/all

...

```

Here's how it looks in my editor (Atom):

![screen shot 2016-07-01 at 9 37 19 pm](https://cloud.githubusercontent.com/assets/51504/16537567/19d9325c-3fd4-11e6-969e-444b7c26d6af.png)
