### PR TITLE
Fixed crashes

### DIFF
--- a/lib/rules/all.js
+++ b/lib/rules/all.js
@@ -18,9 +18,9 @@ for (const rule in rules) {
       return {
         CallExpression: function (node) {
           const callee = node.callee;
-          const objectName = callee.object.name;
+          const objectName = callee.name || (callee.object && callee.object.name);
 
-          if ((objectName === '_' || objectName === 'lodash' || objectName === 'underscore') && callee.property.name === rule) {
+          if ((objectName === '_' || objectName === 'lodash' || objectName === 'underscore') && callee.property && callee.property.name === rule) {
             context.report({
               node,
               message: errorMessage

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -44,3 +44,11 @@ ruleTester.run('underscore.forEach', rules['for-each'], {
     errors: ['Consider using the native Array.prototype.forEach()']
   }]
 });
+
+// Chaining.
+ruleTester.run('_', rules.concat, {
+  valid: [
+    '_(2, [3], [[4]])'
+  ],
+  invalid: []
+});


### PR DESCRIPTION
`callee.object` doesn't always exist nor does `callee.property` even in the context of Underscore/Lo-Dash (see chaining: https://lodash.com/docs#_)

Unrelated, but the `"isNaN"` rule kebab-cases to `is-na-n`, so perhaps it would be better to rename it to `"isNan"` in the JSON file.